### PR TITLE
npm node_modules organization changed

### DIFF
--- a/app.js
+++ b/app.js
@@ -107,7 +107,7 @@ var doForward = function(req, res, baseUrl, p) {
 app.use('/', express.static(__dirname + '/template'));
 
 // addon swagger page
-app.use('/s', express.static(__dirname + '/node_modules/swagger-ui/dist'));
+app.use('/s', express.static(__dirname + '/../swagger-ui/dist'));
 
 // Start web server at port 3000
 var port = config.get("port");


### PR DESCRIPTION
Since a recent version, npm organizes dependencies in a new way in the node_modules folder (in flat way, not recursive). To have swagger-combined working, I must change this.
