### PR TITLE
Changed object initialization to arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,13 +30,13 @@ app.get('/docs', function(req, res) {
             if (!a) {
                 a = i;
                 if (!a.definitions) {
-                    a.definitions = {};
+                    a.definitions = [];
                 }
                 if (!a.paths) {
-                    a.paths = {};
+                    a.paths = [];
                 }
                 if (!a.tags) {
-                    a.tags = {};
+                    a.tags = [];
                 }
             }
             else{


### PR DESCRIPTION
The project stopped working for us after re-deploying the Docker image. It would only work when a single Swagger url was configured, but not when we added a second Swagger url. The initialisation of the arrays as objects seems wrong and changing them fixed the problem.